### PR TITLE
Inverts the serial data flow and reduces rerendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import DriveControl from './components/DriveControl';
 import ArmControl from './components/ArmControl';
@@ -16,8 +16,6 @@ function App() {
     <div>
       <header className='btn-group'>
         <button className='btn btn__primary' onClick={() => setIsDriveControl(!isDriveControl)}>Toggle Mode</button>
-        <button className='btn btn__primary' onClick={() => console.log(commands.current)}>Commands</button>
-        <button className='btn btn__primary' onClick={() => console.log(status)}>Status</button>
         <Serial commands={commands} setStatus={setStatus} />
       </header>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,26 +8,26 @@ import Serial from './components/Serial'
 import { ArmFormat, DriveFormat } from './dto/commands';
 
 function App() {
-  const [toggleMode, setToggleMode] = useState(true)
-  const [roverStatus, setRoverStatus] = useState({ heartbeat_count: 0 })
-  const [roverCommands, setRoverCommands] = useState({})
-  const commands = useRef({})
+  const commands = useRef<string>("");
+  const [isDriveControl, setIsDriveControl] = useState(true)
+  const [status, setStatus] = useState<ArmFormat | DriveFormat>({ heartbeat_count: 0, is_operational: 1, wheel_orientation: 0, drive_mode: "D", speed: 0, angle: 0 });
 
   return (
     <div>
       <header className='btn-group'>
-        <button className='btn btn__primary' onClick={() => setToggleMode(!toggleMode)}>Toggle Mode</button>
-        <button className='btn btn__primary' onClick={() => console.log(commands.current)}>Status</button>
-        {/* <Serial setRoverStatus={setRoverStatus} roverCommands={roverCommands} /> */}
+        <button className='btn btn__primary' onClick={() => setIsDriveControl(!isDriveControl)}>Toggle Mode</button>
+        <button className='btn btn__primary' onClick={() => console.log(commands.current)}>Commands</button>
+        <button className='btn btn__primary' onClick={() => console.log(status)}>Status</button>
+        <Serial commands={commands} setStatus={setStatus} />
       </header>
 
       <div className="grid-container">
-        {toggleMode ? <DriveControl commands={commands} /> : <ArmControl commands={commands} />}
-        <Status roverStatus={roverStatus} />
-        <Camera name="1" src="http://raspberrypi:8000/stream.mjpg" />
-        <Camera name="2" src="http://raspberrypi:8001/stream.mjpg" />
-        <Camera name="3" src="http://raspberrypi:8002/stream.mjpg" />
-        <Camera name="4" src="http://raspberrypi:8003/stream.mjpg" />
+        {isDriveControl ? <DriveControl commands={commands} /> : <ArmControl commands={commands} />}
+        <Status status={status} />
+        <Camera name="0" src="http://raspberrypi:8000/stream.mjpg" />
+        <Camera name="1" src="http://raspberrypi:8001/stream.mjpg" />
+        <Camera name="2" src="http://raspberrypi:8002/stream.mjpg" />
+        <Camera name="3" src="http://raspberrypi:8003/stream.mjpg" />
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
       </header>
 
       <div className="grid-container">
-        {toggleMode ? <DriveControl commands={commands} /> : <ArmControl roverStatus={roverStatus} setRoverCommands={setRoverCommands} />}
+        {toggleMode ? <DriveControl commands={commands} /> : <ArmControl commands={commands} />}
         <Status roverStatus={roverStatus} />
         <Camera name="1" src="http://raspberrypi:8000/stream.mjpg" />
         <Camera name="2" src="http://raspberrypi:8001/stream.mjpg" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,28 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import DriveControl from './components/DriveControl';
 import ArmControl from './components/ArmControl';
 import Camera from './components/Camera'
 import Status from './components/Status';
 import Serial from './components/Serial'
+import { ArmFormat, DriveFormat } from './dto/commands';
 
 function App() {
   const [toggleMode, setToggleMode] = useState(true)
   const [roverStatus, setRoverStatus] = useState({ heartbeat_count: 0 })
   const [roverCommands, setRoverCommands] = useState({})
-
+  const commands = useRef({})
 
   return (
     <div>
       <header className='btn-group'>
         <button className='btn btn__primary' onClick={() => setToggleMode(!toggleMode)}>Toggle Mode</button>
-        <Serial setRoverStatus={setRoverStatus} roverCommands={roverCommands} />
+        <button className='btn btn__primary' onClick={() => console.log(commands.current)}>Status</button>
+        {/* <Serial setRoverStatus={setRoverStatus} roverCommands={roverCommands} /> */}
       </header>
 
       <div className="grid-container">
-        {toggleMode ? <DriveControl roverStatus={roverStatus} setRoverCommands={setRoverCommands} /> : <ArmControl roverStatus={roverStatus} setRoverCommands={setRoverCommands} />}
+        {toggleMode ? <DriveControl commands={commands} /> : <ArmControl roverStatus={roverStatus} setRoverCommands={setRoverCommands} />}
         <Status roverStatus={roverStatus} />
         <Camera name="1" src="http://raspberrypi:8000/stream.mjpg" />
         <Camera name="2" src="http://raspberrypi:8001/stream.mjpg" />

--- a/src/components/ArmControl.tsx
+++ b/src/components/ArmControl.tsx
@@ -1,66 +1,89 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { ArmFormat } from '../dto/commands';
 
-export default function ArmControl({ roverStatus, setRoverCommands }) {
-    const [speed, setSpeed] = useState("0");
-    const [mode, setMode] = useState("D");
-    const [rotundaAngle, setRotundaAngle] = useState("0");
-    const [shoulderAngle, setShoulderAngle] = useState("0");
-    const [elbowAngle, setElbowAngle] = useState("0");
-    const [wristPitch, setWristPitch] = useState("0");
-    const [wristYaw, setWristYaw] = useState("0");
-    const [isOperational, setIsOperational] = useState(1);
-
-    function createRoverCommand() {
-        const heartbeat_count = roverStatus.heartbeat_count ? roverStatus.heartbeat_count : 0;
-        const newCommand = {
-            "heartbeat_count": heartbeat_count,
-            "is_operational": isOperational,
-            "speed": parseInt(speed),
-            "joint_mode": mode,
-            "rotunda_angle": parseInt(rotundaAngle),
-            "shoulder_angle": parseInt(shoulderAngle),
-            "elbow_angle": parseInt(elbowAngle),
-            "wrist_pitch": parseInt(wristPitch),
-            "wrist_yaw": parseInt(wristYaw)
-        };
-        return newCommand;
-    }
+export default function ArmControl({ commands }) {
+    const [armCommands, setArmCommands] = useState<ArmFormat>({ heartbeat_count: 0, is_operational: 1, speed: 0, joint_mode: "D", joint_angles: [0, 0, 0, 0, 0], hand_mode: "C", hand_angles: [0, 0, 0, 0, 0] });
 
     async function handleSubmit(e) {
         e.preventDefault();
-        await setRoverCommands(await createRoverCommand());
+        commands.current = await armCommands;
     }
+
+    function handleChange(e) {
+        setArmCommands({ ...armCommands, [e.target.name]: e.target.value });
+    }
+
+    function handleJointAngleChange(e, index) {
+        const newArray = [...armCommands.joint_angles];
+        newArray[index] = e.target.value;
+        setArmCommands({ ...armCommands, joint_angles: newArray });
+    }
+
+    function handleHandAngleChange(e, index) {
+        const newArray = [...armCommands.hand_angles];
+        newArray[index] = e.target.value;
+        setArmCommands({ ...armCommands, hand_angles: newArray });
+    }
+
+    useEffect(() => {
+        handleSubmit(new Event('submit'));
+    }, [armCommands]);
+
 
     return (
         <div className='serial'>
             <h2>Arm Control</h2>
             <form className='serial-form' onSubmit={handleSubmit}>
                 <label className='label_lg'> Speed
-                    <input autoComplete='false' className='input-text' name="speed" value={speed} onChange={(e) => setSpeed(e.target.value)} />
+                    <input className='input-text' type='number' name="speed" value={armCommands.speed} onChange={handleChange} />
                 </label>
 
-                <label className='label_lg'> Mode
-                    <input autoComplete='false' className='input-text' name="mode" value={mode} onChange={(e) => setMode(e.target.value)} />
+                <label className='label_lg'> Joint Mode
+                    <input className='input-text' type='text' name="joint_mode" value={armCommands.joint_mode} onChange={handleChange} />
                 </label>
 
                 <label className='label_lg'> Rotunda Angle
-                    <input autoComplete='false' className='input-text' name="rotundaAngle" value={rotundaAngle} onChange={(e) => setRotundaAngle(e.target.value)} />
+                    <input className='input-text' type='number' name="joint_angles" value={armCommands.joint_angles[0]} onChange={(e) => handleJointAngleChange(e, 0)} />
                 </label>
 
                 <label className='label_lg'> Shoulder Angle
-                    <input autoComplete='false' className='input-text' name="shoulderAngle" value={shoulderAngle} onChange={(e) => setShoulderAngle(e.target.value)} />
+                    <input className='input-text' type='number' name="joint_angles" value={armCommands.joint_angles[1]} onChange={(e) => handleJointAngleChange(e, 1)} />
                 </label>
 
                 <label className='label_lg'> Elbow Angle
-                    <input autoComplete='false' className='input-text' name="elbowAngle" value={elbowAngle} onChange={(e) => setElbowAngle(e.target.value)} />
+                    <input className='input-text' type='number' name="joint_angles" value={armCommands.joint_angles[2]} onChange={(e) => handleJointAngleChange(e, 2)} />
                 </label>
 
-                <label className='label_lg'> Wrist Pitch Angle
-                    <input autoComplete='false' className='input-text' name="wristPitch" value={wristPitch} onChange={(e) => setWristPitch(e.target.value)} />
+                <label className='label_lg'> Left Wrist Angle
+                    <input className='input-text' type='number' name="joint_angles" value={armCommands.joint_angles[3]} onChange={(e) => handleJointAngleChange(e, 3)} />
                 </label>
 
-                <label className='label_lg'> Wrist Yaw Angle
-                    <input autoComplete='false' className='input-text' name="wristYaw" value={wristYaw} onChange={(e) => setWristYaw(e.target.value)} />
+                <label className='label_lg'> Right Wrist Angle
+                    <input className='input-text' type='number' name="joint_angles" value={armCommands.joint_angles[4]} onChange={(e) => handleJointAngleChange(e, 4)} />
+                </label>
+
+                <label className='label_lg'> Hand Mode
+                    <input className='input-text' type='text' name="hand_mode" value={armCommands.hand_mode} onChange={handleChange} />
+                </label>
+
+                <label className='label_lg'> Pinky Finger Angle
+                    <input className='input-text' type='number' name="hand_angles" value={armCommands.hand_angles[0]} onChange={(e) => handleHandAngleChange(e, 0)} />
+                </label>
+
+                <label className='label_lg'> Ring Finger Angle
+                    <input className='input-text' type='number' name="hand_angles" value={armCommands.hand_angles[1]} onChange={(e) => handleHandAngleChange(e, 1)} />
+                </label>
+
+                <label className='label_lg'> Middle Finger Angle
+                    <input className='input-text' type='number' name="hand_angles" value={armCommands.hand_angles[2]} onChange={(e) => handleHandAngleChange(e, 2)} />
+                </label>
+
+                <label className='label_lg'> Index Finger Angle
+                    <input className='input-text' type='number' name="hand_angles" value={armCommands.hand_angles[3]} onChange={(e) => handleHandAngleChange(e, 3)} />
+                </label>
+
+                <label className='label_lg'> Thumb Finger Angle
+                    <input className='input-text' type='number' name="hand_angles" value={armCommands.hand_angles[4]} onChange={(e) => handleHandAngleChange(e, 4)} />
                 </label>
                 <button className='btn btn__primary btn__lg btn-send' type="submit">Send</button>
             </form>

--- a/src/components/ArmControl.tsx
+++ b/src/components/ArmControl.tsx
@@ -6,7 +6,7 @@ export default function ArmControl({ commands }) {
 
     async function handleSubmit(e) {
         e.preventDefault();
-        commands.current = await armCommands;
+        commands.current = `{"heartbeat_count":${armCommands.heartbeat_count},"is_operational":${armCommands.is_operational},"speed":${armCommands.speed},"joint_mode":"${armCommands.joint_mode}","joint_angles":[${armCommands.joint_angles}],"hand_mode":"${armCommands.hand_mode}","hand_angles":[${armCommands.hand_angles}]}`;
     }
 
     function handleChange(e) {

--- a/src/components/DriveControl.tsx
+++ b/src/components/DriveControl.tsx
@@ -9,7 +9,7 @@ export default function DriveControl({ commands }) {
 
     async function handleSubmit(e) {
         e.preventDefault();
-        commands.current = await driveCommands;
+        commands.current = `{"heartbeat_count":${driveCommands.heartbeat_count},"is_operational":${driveCommands.is_operational},"wheel_orientation":${driveCommands.wheel_orientation},"drive_mode":"${driveCommands.drive_mode}","speed":${driveCommands.speed},"angle":${driveCommands.angle}}`;
     }
 
     function handleChange(e) {

--- a/src/components/DriveControl.tsx
+++ b/src/components/DriveControl.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState, useRef } from 'react'
 import { useGamepads } from 'react-gamepads';
 import { DriveFormat } from '../dto/commands';
 
-export default function DriveControl({ roverStatus, setRoverCommands }) {
+export default function DriveControl({ commands }) {
     useGamepads(gamepads => setGamepads(gamepads[0]));
-    const [gamepads, setGamepads] = useState<Gamepad>();
-    const [driveCommands, setDriveCommands] = useState<DriveFormat>({ heartbeat_count: 0, is_operational: 1, wheel_orientation: 0, drive_mode: "D", speed: 0, angle: 0 });
+    const [gamepad, setGamepads] = useState<Gamepad>();
+    const [driveCommands, setDriveCommands] = useState<DriveFormat>({ heartbeat_count: 0, is_operational: 1, wheel_orientation: 0, speed: 0, angle: 0, drive_mode: "D" });
 
     async function handleSubmit(e) {
         e.preventDefault();
-        console.log(driveCommands);
+        commands.current = await driveCommands;
     }
 
     function handleChange(e) {
@@ -17,12 +17,13 @@ export default function DriveControl({ roverStatus, setRoverCommands }) {
     }
 
     useEffect(() => {
-        const newWheelOrientation: number = gamepads?.buttons[6]?.value ? 0 : gamepads?.buttons[8]?.value ? 1 : gamepads?.buttons[10]?.value ? 2 : driveCommands.wheel_orientation;
-        const newDriveMode: string = gamepads?.buttons[7]?.value ? "D" : gamepads?.buttons[9]?.value ? "T" : gamepads?.buttons[11]?.value ? "S" : driveCommands.drive_mode;
-        const newSpeed: number = parseInt((-(gamepads?.axes[1]) * 100).toFixed(0));
-        const newAngle: number = parseInt(((gamepads?.axes[2]) * 12).toFixed(0));
+        const newWheelOrientation: number = gamepad?.buttons[6]?.value ? 0 : gamepad?.buttons[8]?.value ? 1 : gamepad?.buttons[10]?.value ? 2 : driveCommands.wheel_orientation;
+        const newDriveMode: string = gamepad?.buttons[7]?.value ? "D" : gamepad?.buttons[9]?.value ? "T" : gamepad?.buttons[11]?.value ? "S" : driveCommands.drive_mode;
+        const newSpeed: number = gamepad?.axes[1] && gamepad?.buttons[0].pressed ? parseInt((-(gamepad?.axes[1]) * 100).toFixed(0)) : 0;
+        const newAngle: number = gamepad?.axes[0] ? parseInt((gamepad?.axes[0] * 12).toFixed(0)) : driveCommands.angle;
         setDriveCommands({ ...driveCommands, wheel_orientation: newWheelOrientation, drive_mode: newDriveMode, angle: newAngle, speed: newSpeed });
-    }, [gamepads]);
+        handleSubmit(new Event('submit'));
+    }, [gamepad]);
 
     return (
         <div className='serial'>

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -1,10 +1,10 @@
 import { memo } from 'react'
 
-const Status = ({ roverStatus }) => {
+const Status = ({ status }) => {
     return (
         <div>
             <h2>Rover Status</h2>
-            <pre>{JSON.stringify(roverStatus, null, 2)}</pre>
+            <pre>{JSON.stringify(status, null, 2)}</pre>
         </div>
     )
 }


### PR DESCRIPTION
Tested the new serial logic with urc main. The joystick does not require any delays or useEffect as web serial will only write when told to (receives JSON).

Drive and Arm Control have been updated to  be much more performant, much less re-rendering when grabbing gamepad state.

Command is made to use useRef instead of useState to reduce re-renders too. Commands is now hardcoded to a string to prevent JSON.stringify from improperly ordering commands.